### PR TITLE
[DEMO-2502] Use root_user_password if in deployment config

### DIFF
--- a/deploy/linux/mariadb/roles/start/tasks/main.yml
+++ b/deploy/linux/mariadb/roles/start/tasks/main.yml
@@ -12,33 +12,9 @@
     msg: "database_password is required"
   when: database_password is not defined
 
-- name: Set root password file path
-  set_fact:
-    root_cred_file_path: /usr/local/etc/mysql_root
-
-- name: Generate temp password
-  set_fact:
-    temp_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
-
-- name: Save root password to host (idempotent)
-  copy:
-    # use root_user_password if defined in deployment config. otherwise, use generated password.
-    content: "{{ root_user_password | default(temp_password) }}"
-    dest: "{{ root_cred_file_path }}"
-    owner: root
-    mode: 0700
-    force: false
-  become: yes
-  
-- name: Read in the root password
-  slurp:
-    src: "{{ root_cred_file_path }}"
-  register: encoded_root_password
-  become: yes
-
-- name: Decode the root password
-  set_fact:
-    root_password: "{{ encoded_root_password.content | b64decode }}"
+- fail:
+    msg: "database_root_password is required"
+  when: database_root_password is not defined
 
 - name: Start mariadb
   service:
@@ -50,16 +26,16 @@
 - name: Setup root user
   mysql_user:
     login_user: "root"
-    login_password: "{{ root_password }}"
+    login_password: "{{ database_root_password }}"
     user: "root"
-    password: "{{ root_password }}"
+    password: "{{ database_root_password }}"
     check_implicit_admin: true
     host: localhost
 
 - name: Remove remote root
   mysql_user:
     login_user: "root"
-    login_password: "{{ root_password }}"
+    login_password: "{{ database_root_password }}"
     user: "root"
     host: "{{ ansible_fqdn }}"
     check_implicit_admin: true
@@ -68,7 +44,7 @@
 - name: Create db user
   mysql_user:
     login_user: "root"
-    login_password: "{{ root_password }}"
+    login_password: "{{ database_root_password }}"
     name: "{{ database_user }}"
     password: "{{ database_password }}"
     host: "%"


### PR DESCRIPTION
* Updated the role to use a user defined root_user_password if
available. Otherwise, the role just uses the password it generates.